### PR TITLE
Avoid divide-by-zero case

### DIFF
--- a/src/clojurewerkz/eep/stats.clj
+++ b/src/clojurewerkz/eep/stats.clj
@@ -8,8 +8,10 @@
 (defn mean
   "Calculates mean"
   [vals]
-  (let [non-nil (map identity vals)]
-    (/ (reduce + non-nil) (count non-nil))))
+  (let [non-nil (keep identity vals)
+        cnt (count non-nil)]
+    (when (pos? cnt)
+      (/ (reduce + non-nil) cnt))))
 
 (defn variance
   "Calculates variance, deviation from mean value"


### PR DESCRIPTION
Returning nil if no items. ```(+)``` was considered, but callers can always do

```clojure
(or (mean vals) 0)
```